### PR TITLE
Updated disambiguate.py sort to newer syntax

### DIFF
--- a/disambiguate.py
+++ b/disambiguate.py
@@ -178,9 +178,9 @@ def main(args):
         humanfilenamesorted = path.join(intermdir,humanprefix+".speciesA.namesorted.bam")
         mousefilenamesorted = path.join(intermdir,mouseprefix+".speciesB.namesorted.bam")
         if not path.isfile(humanfilenamesorted):
-            pysam.sort("-n","-m","2000000000",humanfilename,humanfilenamesorted.replace(".bam",""))
+            pysam.sort("-n","-m","2000000000","-o",humanfilenamesorted,humanfilename)
         if not path.isfile(mousefilenamesorted):
-            pysam.sort("-n","-m","2000000000",mousefilename,mousefilenamesorted.replace(".bam",""))
+            pysam.sort("-n","-m","2000000000","-o",mousefilenamesorted,mousefilename)
    # read in human reads and form a dictionary
     myHumanFile = pysam.Samfile(humanfilenamesorted, "rb" )
     myMouseFile = pysam.Samfile(mousefilenamesorted, "rb" )


### PR DESCRIPTION
As of of samtools 1.3 and later (https://github.com/samtools/samtools/releases/tag/1.3), the samtools sort syntax aka "samtools sort in.bam out.prefix" has been removed from samtools (and thus from pysam calls to samtools). I changed the two lines making the pysam sort calls to reflect the newer syntax, so it will work with up to date versions of samtools.